### PR TITLE
Correct BOOST library dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ ENDIF(NOT GETTEXT_MSGFMT_EXECUTABLE)
 add_executable(adriconf ${SOURCE_FILES})
 
 target_link_libraries(adriconf ${GTKMM_LIBRARIES})
-target_link_libraries(adriconf ${Boost_LIBRARIES})
+target_link_libraries(adriconf ${Boost_LOCALE_LIBRARIES})
 target_link_libraries(adriconf ${LibXML++_LIBRARIES})
 target_link_libraries(adriconf ${X11_LIBRARIES})
 target_link_libraries(adriconf ${OPENGL_gl_LIBRARY})


### PR DESCRIPTION
At least on my system Boost_LIBRARIES doesn't cut it, and in my experience when giving COMPONENTS in the Find command one always has to give the specific libraries. 