### PR TITLE
compile DriConf.glade into adriconf as resource.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ set(SOURCE_FILES main.cpp Device.cpp Device.h
         ConfigurationResolver.cpp ConfigurationResolver.h
         DRIQuery.cpp DRIQuery.h
         DriverConfiguration.cpp DriverConfiguration.h
-        Writer.cpp Writer.h GUI.cpp GUI.h ConfigurationLoader.cpp ConfigurationLoader.h ApplicationOption.cpp ApplicationOption.h)
+        Writer.cpp Writer.h GUI.cpp GUI.h ConfigurationLoader.cpp ConfigurationLoader.h ApplicationOption.cpp ApplicationOption.h
+        resources.c)
 
 find_package(PkgConfig REQUIRED)
 find_package(OpenGL REQUIRED)
@@ -88,6 +89,14 @@ target_link_libraries(adriconf ${LibXML++_LIBRARIES})
 target_link_libraries(adriconf ${X11_LIBRARIES})
 target_link_libraries(adriconf ${OPENGL_gl_LIBRARY})
 target_link_libraries(adriconf ${Gtest_LIBRARIES})
+
+add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/resources.c
+    COMMAND glib-compile-resources adriconf.gresource.xml --target=resources.c --generate-source
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_source_files_properties(${CMAKE_SOURCE_DIR}/resources.c PROPERTIES
+    GENERATED TRUE
+)
 
 # Move the glade file
 add_custom_command(

--- a/GUI.cpp
+++ b/GUI.cpp
@@ -36,7 +36,7 @@ DRI::GUI::GUI() : currentApp(nullptr) {
 
     /* Load the GUI file */
     this->gladeBuilder = Gtk::Builder::create();
-    this->gladeBuilder->add_from_file("DriConf.glade");
+    this->gladeBuilder->add_from_resource("/jlHertel/adriconf/DriConf.glade");
 
     /* Extract the main object */
     this->gladeBuilder->get_widget("mainwindow", this->pWindow);

--- a/adriconf.gresource.xml
+++ b/adriconf.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+	<gresource prefix="/jlHertel/adriconf">
+		<file preprocess="xml-stripblanks">DriConf.glade</file>
+	</gresource>
+</gresources>


### PR DESCRIPTION
This allows to install the adriconf binary to e.g. /usr/bin/ without having to carry the glade file