### PR TITLE
Add support for XWayland systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCE_FILES Device.cpp Device.h
         Application.cpp Application.h
         ConfigurationResolver.cpp ConfigurationResolver.h
         DRIQuery.cpp DRIQuery.h
+        HelpersWayland.cpp HelpersWayland.h
         DriverConfiguration.cpp DriverConfiguration.h
         Writer.cpp Writer.h GUI.cpp GUI.h ConfigurationLoader.cpp ConfigurationLoader.h ApplicationOption.cpp ApplicationOption.h
         resources.c GPUInfo.cpp GPUInfo.h PCIDatabaseQuery.cpp PCIDatabaseQuery.h ComboBoxColumn.h DriverOptionType.h)
@@ -70,6 +71,15 @@ find_package(Gettext REQUIRED)
 include_directories(${INTL_INCLUDE_DIRS})
 link_directories(${INTL_LIBRARY_DIRS})
 
+#EGL
+#Use these libs if running on Wayland
+if(ENABLE_XWAYLAND)
+    message(STATUS "XDG_SESSION_TYPE = " $ENV{XDG_SESSION_TYPE})
+    pkg_check_modules(EGL REQUIRED egl)
+    include_directories(${EGL_INCLUDE_DIRS})
+    link_directories(${EGL_LIBRARY_DIRS})
+endif()
+
 #INTL INSTALL TRANSLATIONS
 GETTEXT_CREATE_TRANSLATIONS(po/adriconf.pot ALL po/en.po po/hr.po po/pt_BR.po)
 
@@ -86,6 +96,10 @@ if(OpenGL_GLX_FOUND)
 endif()
 target_link_libraries(adriconf ${DRM_LIBRARIES})
 target_link_libraries(adriconf ${PCILIB_LIBRARIES})
+if (ENABLE_XWAYLAND)
+    target_link_libraries(adriconf ${EGL_LIBRARIES})
+    target_compile_definitions(adriconf PRIVATE ENABLE_XWAYLAND)
+endif()
 
 add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/resources.c
     COMMAND glib-compile-resources adriconf.gresource.xml --target=resources.c --generate-source

--- a/DRIQuery.h
+++ b/DRIQuery.h
@@ -3,31 +3,33 @@
 
 #include "DriverConfiguration.h"
 #include "Parser.h"
+#include "GPUInfo.h"
+#include "HelpersWayland.h"
 
 #include <GL/glx.h>
 #include <GL/glxext.h>
 #include <X11/Xlib.h>
 #include <glibmm/ustring.h>
-#include "GPUInfo.h"
 
 /* MESA HAS THIS HARD-CODED SO WE MUST HARD-CODE IT ALSO */
 #define MESA_MAX_DRM_DEVICES 32
 
 typedef const char *glXGetScreenDriver_t(Display *dpy, int scrNum);
-
 typedef const char *glXGetDriverConfig_t(const char *driverName);
-
 typedef const char *glXQueryExtensionsString_t(Display *dpy, int screen);
+
 
 class DRIQuery {
 private:
     glXGetScreenDriver_t *getScreenDriver;
     glXGetDriverConfig_t *getDriverConfig;
     glXQueryExtensionsString_t *getGlxExtensionsString;
+    const char *queryDriverName(int screen);
+    const char *queryDriverConfig(const char *dn);
 
 public:
     DRIQuery();
-
+    bool isSystemSupported();
     bool canHandle();
 
     std::list<DriverConfiguration> queryDriverConfigurationOptions(const Glib::ustring &locale);

--- a/HelpersWayland.cpp
+++ b/HelpersWayland.cpp
@@ -1,0 +1,169 @@
+#ifdef ENABLE_XWAYLAND
+
+#include <iostream>
+#include <X11/Xlib.h>
+#include <glibmm/i18n.h>
+
+#include "HelpersWayland.h"
+
+bool HelpersWayland::hasProperLibEGL() {
+    driverName = (eglGetDisplayDriverName_t *) eglGetProcAddress("eglGetDisplayDriverName");
+    driverConfig = (eglGetDisplayDriverconfig_t *) eglGetProcAddress("eglGetDisplayDriverConfig");
+
+    if (!driverName || !driverConfig) {
+        std::cerr << _("Error getting function pointers. LibEGL must be too old.\n");
+        return false;
+    }
+
+    return true;
+}
+
+void HelpersWayland::setup_x(const char *display_name,
+        Display** out_display,
+        int screenXlib,
+        Window* out_window) {
+
+
+    Display* display = XOpenDisplay(display_name);
+    if (!display)
+         std::cerr << ("XOpenDisplay() failed\n");
+
+    Window w = XCreateSimpleWindow(
+                display, XDefaultRootWindow(display),
+                0, 0, 64, 64, 4, 0, 0);
+
+    XMapWindow(display, w);
+
+    *out_display = display;
+    *out_window = w;
+}
+
+void HelpersWayland::setup_egl(
+        EGLint api,
+        EGLNativeDisplayType native_display,
+        EGLNativeWindowType native_window,
+        EGLDisplay* out_display,
+        EGLConfig* out_config,
+        EGLContext* out_context,
+        EGLSurface* out_window_surface) {
+
+    EGLint ignore;
+    EGLBoolean ok;
+
+    ok = eglBindAPI(api);
+    if (!ok)
+        std::cerr << _("eglBindAPI(0x%x) failed\n");
+
+    EGLDisplay display = eglGetDisplay(native_display);
+    if (display == EGL_NO_DISPLAY)
+        std::cerr << _("eglGetDisplay() failed\n");
+
+    ok = eglInitialize(display, &ignore, &ignore);
+    if (!ok)
+        std::cerr << _("eglInitialize() failed\n");
+
+    EGLint configs_size = 256;
+    EGLConfig* configs = new EGLConfig[configs_size];
+    EGLint num_configs;
+    ok = eglChooseConfig(
+        display,
+        NULL,
+        configs,
+        configs_size, // num requested configs
+        &num_configs); // num returned configs
+    if (!ok)
+        std::cerr << _("eglChooseConfig() failed\n");
+    if (num_configs == 0)
+        std::cerr << _("failed to find suitable EGLConfig\n");
+    EGLConfig config = configs[0];
+    delete [] configs;
+
+    EGLContext context = eglCreateContext(
+        display,
+        config,
+        EGL_NO_CONTEXT,
+        NULL);
+    if (!context)
+        std::cerr << _("eglCreateContext() failed\n");
+
+    EGLSurface surface = eglCreateWindowSurface(
+        display,
+        config,
+        native_window,
+        NULL);
+    if (!surface)
+        std::cerr << _("eglCreateWindowSurface() failed\n");
+
+    ok = eglMakeCurrent(display, surface, surface, context);
+    if (!ok)
+    std::cerr << _("eglMakeCurrent() failed\n");
+
+    *out_display = display;
+    *out_config = config;
+    *out_context = context;
+    *out_window_surface = surface;
+}
+
+const char *HelpersWayland::queryDriverName(int screen) {
+    const char *x_display_name = NULL;
+    Display *x_display;
+    int x_screen = screen;
+    Window x_window;
+
+    const char *ret;
+    setup_x(x_display_name,
+            &x_display,
+            x_screen,
+            &x_window);
+
+    EGLDisplay egl_display;
+    EGLConfig egl_config;
+    EGLContext egl_context;
+    EGLSurface egl_surface;
+    setup_egl(EGL_OPENGL_API,
+              x_display,
+              x_window,
+              &egl_display,
+              &egl_config,
+              &egl_context,
+              &egl_surface);
+
+
+    driverName = (eglGetDisplayDriverName_t *) eglGetProcAddress("eglGetDisplayDriverName");
+    ret = (* driverName) (egl_display);
+
+    XCloseDisplay(x_display);
+    return ret;
+}
+
+const char *HelpersWayland::queryDriverConfig(const char *dn) {
+    const char *x_display_name = NULL;
+    Display *x_display;
+    int x_screen = 0;
+    Window x_window;
+    setup_x(x_display_name,
+            &x_display,
+            x_screen,
+            &x_window);
+
+    EGLDisplay egl_display;
+    EGLConfig egl_config;
+    EGLContext egl_context;
+    EGLSurface egl_surface;
+    setup_egl(EGL_OPENGL_API,
+              x_display,
+              x_window,
+              &egl_display,
+              &egl_config,
+              &egl_context,
+              &egl_surface);
+
+
+    driverConfig = (eglGetDisplayDriverconfig_t *) eglGetProcAddress("eglGetDisplayDriverConfig");
+    const char * config = (* driverConfig) (egl_display);
+
+    XCloseDisplay(x_display);
+    return config;
+}
+
+#endif // ENABLE_XWAYLAND

--- a/HelpersWayland.h
+++ b/HelpersWayland.h
@@ -1,0 +1,43 @@
+#ifdef ENABLE_XWAYLAND
+
+#ifndef HELPERS_WAYLAND
+#define HELPERS_WAYLAND
+
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+
+#include <EGL/egl.h>
+
+typedef const char *eglGetDisplayDriverName_t(EGLDisplay disp);
+typedef const char *eglGetDisplayDriverconfig_t(EGLDisplay disp);
+
+class HelpersWayland
+{
+private:
+    eglGetDisplayDriverName_t *driverName;
+    eglGetDisplayDriverconfig_t *driverConfig;
+
+    void setup_x(const char *display_name,
+            Display** out_display,
+            int screenXlib,
+            Window* out_window);
+    void setup_egl(
+            EGLint api,
+            EGLNativeDisplayType native_display,
+            EGLNativeWindowType native_window,
+            EGLDisplay* out_display,
+            EGLConfig* out_config,
+            EGLContext* out_context,
+            EGLSurface* out_window_surface);
+
+public:
+    HelpersWayland() {}
+    bool hasProperLibEGL();
+    const char *queryDriverName(int screen);
+    const char *queryDriverConfig(const char *dn);
+};
+
+#endif //ENABLE_XWAYLAND
+#endif //HELPERS_WAYLAND

--- a/main.cpp
+++ b/main.cpp
@@ -7,22 +7,37 @@
 int main(int argc, char *argv[]) {
     /* Start the GUI work */
     auto app = Gtk::Application::create(argc, argv, "br.com.jeanhertel.adriconf");
-    try {
-        DRIQuery check;
+
+    char *protocol = std::getenv("XDG_SESSION_TYPE");
+
+    DRIQuery check;
+    if (!check.isSystemSupported()) {
+        return 1;
+    }
+    if (std::string(protocol) == "wayland") {
+        std::cout << _("adriconf running on Wayland\n");
+    } else if (std::string(protocol) == "x11"){
+        std::cout << _("adriconf running on X11\n");
 
         //Error window pops up even when a screen has a driver which we can't configure
         if (!check.canHandle()) {
-            std::cerr << "Not all screens have open source drivers" << std::endl;
+            std::cerr << _("Not all screens have open source drivers") << std::endl;
+
             //pop up error window here
             Gtk::MessageDialog *errorDialog = new Gtk::MessageDialog("Closed source driver(s) detected!",
-                                                                false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_CLOSE);
+                                                                     false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_CLOSE);
             errorDialog->set_secondary_text("Currently adriconf cannot handle closed source drivers.");
-	    if (errorDialog->run()) {
-		errorDialog->close();
-            	return 0;
-	    }
+            if (errorDialog->run()) {
+                errorDialog->close();
+                return 0;
+            }
         }
+    } else {
+        std::cout << _("Unknow display server protocol being used\n");
+        return 1;
+    }
 
+    try {
         GUI gui;
 
         /* No need to worry about the window pointer as the gui object owns it */

--- a/po/adriconf.pot
+++ b/po/adriconf.pot
@@ -172,6 +172,10 @@ msgstr ""
 msgid "The application was successfully added. Reloading default app options."
 msgstr ""
 
+#: ../main.cpp:24
+msgid "Not all screens have open source drivers"
+msgstr ""
+
 #: ../DRIQuery.cpp:18
 msgid "Error getting function pointers. LibGL must be too old."
 msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -120,6 +120,10 @@ msgstr "Generating final XML for saving..."
 msgid "Main window object is not in glade file!"
 msgstr "Main window object is not in glade file!"
 
+#: ../main.cpp:24
+msgid "Not all screens have open source drivers"
+msgstr ""
+
 #: ../GUI.cpp:280
 msgid "Notebook object not found in glade file!"
 msgstr "Notebook object not found in glade file!"

--- a/po/hr.po
+++ b/po/hr.po
@@ -120,6 +120,10 @@ msgstr "Stvaranje konačnog XML-a za spremanje..."
 msgid "Main window object is not in glade file!"
 msgstr "Glavnog objekta prozora nema u glade datoteci!"
 
+#: ../main.cpp:24
+msgid "Not all screens have open source drivers"
+msgstr ""
+
 #: ../GUI.cpp:280
 msgid "Notebook object not found in glade file!"
 msgstr "Objekta bilješke nema u glade datoteci!"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -120,6 +120,10 @@ msgstr "Gerando XML final para salvar..."
 msgid "Main window object is not in glade file!"
 msgstr "Objeto window principal não está no arquivo glade!"
 
+#: ../main.cpp:24
+msgid "Not all screens have open source drivers"
+msgstr ""
+
 #: ../GUI.cpp:280
 msgid "Notebook object not found in glade file!"
 msgstr "Objeto Notebook não encontrado no arquivo glade!"


### PR DESCRIPTION
- Set ENABLE_XWAYLAND cmake variable to run adriconf on xwayland systems
- Create a helper class for wayland and use these functions in
  DRIQuery if protocol used is Wayland.
- Check $XDG_SESSION_TYPE for display server protocol