### PR TITLE
Desktop file: Lower min spec requirement

### DIFF
--- a/flatpak/br.com.jeanhertel.adriconf.desktop
+++ b/flatpak/br.com.jeanhertel.adriconf.desktop
@@ -2,9 +2,9 @@
 Name=adriconf
 GenericName=Advanced DRI Configurator
 Comment=A GUI tool used to configure open source graphics drivers
-Version=1.4
+Version=1.1
 Exec=adriconf
 Type=Application
 Terminal=false
 Icon=br.com.jeanhertel.adriconf
-Categories=Graphics;HardwareSettings;GNOME;GTK
+Categories=Settings;HardwareSettings;GNOME;GTK


### PR DESCRIPTION
The current file does not use any features of version 1.4,
nor actually of anything newer than 1.0 (but I set 1.1 which is
supported by desktop-file-validate 0.23 and might be used in the
future if e.g. Keywords were added).

The latest release of `desktop-file-utils` only supports up to version 1.2.

Also replaced "Graphics" by "Settings" to satisfy:
```
hint: value item "HardwareSettings" in key "Categories" in group "Desktop Entry"
can be extended with another category among the following categories: Settings
```
(Both "Graphics" and "Settings" are "Main Categories", and can't be used together.
"Graphics" is meant for "Application for viewing, creating or processing graphics".)